### PR TITLE
Remove double white space in script output

### DIFF
--- a/check_snmp_netint.pl
+++ b/check_snmp_netint.pl
@@ -2162,6 +2162,8 @@ else {
   $exit_status="CRITICAL";
   print $print_out,": ", $num_int-$num_ok, " int NOK : CRITICAL";
 }
+# Remove double white space in perfdata output, fixing webinterface's output for Icinga2.
+$perf_out =~ s/  / /g;
 print " | ",$perf_out if defined($perf_out);
 print "\n";
 exit $ERRORS{$exit_status};


### PR DESCRIPTION
We had an issue where the first perfdata key of the second network interface would not display in the web interface, turns out it was the double white space in front of it causing the issue. This quick'n'dirty fix solved it.

There might be a better way to do this.