### PR TITLE
newer snmpnetstat reports tcp connections as 'tcp4'

### DIFF
--- a/check_netstat.pl
+++ b/check_netstat.pl
@@ -727,7 +727,7 @@ while (<SHELL_DATA>) {
       }
     }
     else { # $netstat_format==1 || $netstat_format==2 || $netstat_format==4
-      if (/^$o_proto\s/) {
+      if (/^${o_proto}4?\s/) {
         ($port_local, $port_remote, $conn_state) = parse_netstatline($_, $netstat_format);
       }
     }


### PR DESCRIPTION
This seem to have happened somewhere around version 5.7.3. The command line option still wants tcp and dismisses tcp4 though.

A more sophisticated solution would look at the snmpnetstat version and specifically replace 'tcp' with 'tcp4' in the regex but this does the job without much hassle.